### PR TITLE
Bug fix: Fix model_selection_check()

### DIFF
--- a/peak_performance/pipeline.py
+++ b/peak_performance/pipeline.py
@@ -1409,7 +1409,7 @@ def selected_models_to_template(
 
 
 def model_selection_check(
-    result_df: pandas.DataFrame, ic: str, elpd_threshold: Union[str, float] = 25
+    result_df: pandas.DataFrame, ic: str, elpd_threshold: Union[str, float] = 35
 ) -> str:
     """
     During model seleciton, double peak models are sometimes incorrectly preferred due to their increased complexity.
@@ -1435,10 +1435,11 @@ def model_selection_check(
     selected_model = str(result_df.index[0])
     if "double" in selected_model:
         df_single_peak_models = result_df[~result_df.index.str.contains("double")]
-        elpd_single = max(list(df_single_peak_models[f"elpd_{ic}"]))
-        elpd_double = max(list(result_df[f"elpd_{ic}"]))
-        if not elpd_double > elpd_single + elpd_threshold:
-            selected_model = str(df_single_peak_models.index[0])
+        if len(df_single_peak_models) > 0:
+            elpd_single = max(list(df_single_peak_models[f"elpd_{ic}"]))
+            elpd_double = max(list(result_df[f"elpd_{ic}"]))
+            if not elpd_double > elpd_single + elpd_threshold:
+                selected_model = str(df_single_peak_models.index[0])
     return selected_model
 
 

--- a/peak_performance/test_pipeline.py
+++ b/peak_performance/test_pipeline.py
@@ -636,8 +636,15 @@ def test_model_selection_check():
     assert selected_model == "normal"
     # case 2: double peak exceeds elpd score difference threshold and is thusly accepted
     result_df = pandas.DataFrame(
-        {"elpd_loo": [50, 30, 10, -5], "ic": ["loo", "loo", "loo", "loo"]},
+        {"elpd_loo": [50, 30, 20, -5], "ic": ["loo", "loo", "loo", "loo"]},
         index=["double_normal", "double_skew_normal", "normal", "skew_normal"],
+    )
+    selected_model = pl.model_selection_check(result_df, "loo", 25)
+    assert selected_model == "double_normal"
+    # case 3: single peak models were excluded
+    result_df = pandas.DataFrame(
+        {"elpd_loo": [50, 30], "ic": ["loo", "loo"]},
+        index=["double_normal", "double_skew_normal"],
     )
     selected_model = pl.model_selection_check(result_df, "loo", 25)
     assert selected_model == "double_normal"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "peak_performance"
-version = "0.6.4"
+version = "0.6.5"
 authors = [
     {name = "Jochen Nießer", email = "j.niesser@fz-juelich.de"},
     {name = "Michael Osthege", email = "m.osthege@fz-juelich.de"},


### PR DESCRIPTION
When all single peak models are excluded, this method caused an error since the comparison of elpds between single and double peak models is not possible, any more. The fix checks whether any single peak models have been included before the comparison. The unit tests were changed accordingly and the default elpd treshold was increased.