### PR TITLE
Refactor ordering workaround to fix multi-peak models

### DIFF
--- a/peak_performance/models.py
+++ b/peak_performance/models.py
@@ -193,7 +193,7 @@ def define_model_normal(time: np.ndarray, intensity: np.ndarray) -> pm.Model:
 
 def double_model_mean_prior(time):
     """
-    Function creating prior probability distributions for double peaks using a ZeroSumNormal distribution.
+    Function creating prior probability distributions for multi-peaks using a ZeroSumNormal distribution.
 
     Parameters
     ----------
@@ -203,23 +203,26 @@ def double_model_mean_prior(time):
     Returns
     -------
     mean
-        Normally distributed prior for the ordered means of the double peak model.
+        Normally distributed prior for the ordered means of the multi-peak model.
     diff
-        Difference between meanmean and mean.
+        Difference between the group mean and peak-wise mean.
     meanmean
-        Normally distributed prior for the mean of the double peak means.
+        Normally distributed prior for the group mean of the peak means.
     """
+    pmodel = pm.modelcontext(None)
     meanmean = pm.Normal("meanmean", mu=np.min(time) + np.ptp(time) / 2, sigma=np.ptp(time) / 6)
     diff = pm.ZeroSumNormal(
         "diff",
         sigma=1,
-        shape=(2,),  # currently no dims due to bug with ordered transformation
+        # Support arbitrary number of subpeaks
+        shape=len(pmodel.coords["subpeak"]),
+        # NOTE: As of PyMC v5.13, the OrderedTransform and ZeroSumTransform are incompatible.
+        # See https://github.com/pymc-devs/pymc/issues/6975.
+        # As a workaround we'll call pt.sort a few lines below.
     )
-    mean = pm.Normal(
+    mean = pm.Deterministic(
         "mean",
-        mu=meanmean + diff,
-        sigma=1,
-        transform=pm.distributions.transforms.ordered,
+        meanmean + pt.sort(diff),
         dims=("subpeak",),
     )
     return mean, diff, meanmean

--- a/peak_performance/pipeline.py
+++ b/peak_performance/pipeline.py
@@ -489,6 +489,7 @@ def sampling(pmodel, **sample_kwargs):
     idata
         Inference data object.
     """
+    sample_kwargs.setdefault("chains", 4)
     sample_kwargs.setdefault("tune", 2000)
     sample_kwargs.setdefault("draws", 2000)
     # check if nutpie is available; if so, use it to enhance performance

--- a/peak_performance/test_models.py
+++ b/peak_performance/test_models.py
@@ -158,21 +158,20 @@ class TestDistributions:
 
 
 @pytest.mark.parametrize(
-    "model_type", ["normal", "skew_normal", "double_normal", "double_skew_normal"]
+    "model_type,define_func",
+    [
+        ("normal", models.define_model_normal),
+        ("skew_normal", models.define_model_skew),
+        ("double_normal", models.define_model_double_normal),
+        ("double_skew_normal", models.define_model_double_skew_normal),
+    ],
 )
-def test_pymc_sampling(model_type):
+def test_pymc_sampling(model_type, define_func):
     timeseries = np.load(
         Path(__file__).absolute().parent.parent / "example" / "A2t2R1Part1_132_85.9_86.1.npy"
     )
 
-    if model_type == models.ModelType.Normal:
-        pmodel = models.define_model_normal(timeseries[0], timeseries[1])
-    elif model_type == models.ModelType.SkewNormal:
-        pmodel = models.define_model_skew(timeseries[0], timeseries[1])
-    elif model_type == models.ModelType.DoubleNormal:
-        pmodel = models.define_model_double_normal(timeseries[0], timeseries[1])
-    elif model_type == models.ModelType.DoubleSkewNormal:
-        pmodel = models.define_model_double_skew_normal(timeseries[0], timeseries[1])
+    pmodel = define_func(timeseries[0], timeseries[1])
     with pmodel:
         idata = pm.sample(cores=2, chains=2, tune=3, draws=5)
     if model_type in [models.ModelType.DoubleNormal, models.ModelType.DoubleSkewNormal]:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "peak_performance"
-version = "0.6.5"
+version = "0.7.0"
 authors = [
     {name = "Jochen Nießer", email = "j.niesser@fz-juelich.de"},
     {name = "Michael Osthege", email = "m.osthege@fz-juelich.de"},


### PR DESCRIPTION
This fixes a problem in the gradient of our previous workaround.
Also, the previous workaround unnecessarily introduced a
`Normal` just so we could apply the ordered transform.

The minor version number was increased, because
this changes the structure of multi-peak models.