### PR TITLE
Refactor plots and change terminology

### DIFF
--- a/peak_performance/models.py
+++ b/peak_performance/models.py
@@ -118,9 +118,9 @@ def baseline_slope_prior_params(slope_guess: Union[float, int]) -> Mapping[str, 
     }
 
 
-def normal_posterior(baseline, time: np.ndarray, mean, std, *, height):
+def normal_peak_shape(baseline, time: np.ndarray, mean, std, *, height):
     """
-    Model a peak shaped like the PDF of a normal distribution.
+    Model a peak shaped like a normal distribution.
 
     Parameters
     ----------
@@ -182,7 +182,7 @@ def define_model_normal(time: np.ndarray, intensity: np.ndarray) -> pm.Model:
         pm.Deterministic("area", height / (1 / (std * np.sqrt(2 * np.pi))))
         pm.Deterministic("sn", height / noise)
         # posterior
-        y = normal_posterior(baseline, time, mean, std, height=height)
+        y = normal_peak_shape(baseline, time, mean, std, height=height)
         y = pm.Deterministic("y", y)
 
         # likelihood
@@ -225,9 +225,9 @@ def double_model_mean_prior(time):
     return mean, diff, meanmean
 
 
-def double_normal_posterior(baseline, time: np.ndarray, mean, std, *, height):
+def double_normal_peak_shape(baseline, time: np.ndarray, mean, std, *, height):
     """
-    Define a univariate ordered normal distribution as the posterior.
+    Model a peak shaped like a univariate ordered normal distribution.
 
     Parameters
     ----------
@@ -302,7 +302,7 @@ def define_model_double_normal(time: np.ndarray, intensity: np.ndarray) -> pm.Mo
         mean, diff, meanmean = double_model_mean_prior(time)
 
         # posterior
-        y = double_normal_posterior(baseline, time, mean, std, height=height)
+        y = double_normal_peak_shape(baseline, time, mean, std, height=height)
         y = pm.Deterministic("y", y)
 
         # likelihood
@@ -430,9 +430,9 @@ def height_calculation(area, loc, scale, alpha, mode_skew):
     )
 
 
-def skew_normal_posterior(baseline, time, mean, std, alpha, *, area):
+def skew_normal_peak_shape(baseline, time, mean, std, alpha, *, area):
     """
-    Define a skew normally distributed posterior.
+    Model a peak shaped like a skew normal distribution.
 
     Parameters
     ----------
@@ -528,7 +528,7 @@ def define_model_skew(time: np.ndarray, intensity: np.ndarray) -> pm.Model:
             height_formula,
         )
         pm.Deterministic("sn", height / noise)
-        y = skew_normal_posterior(baseline, time, mean, std, alpha, area=area)
+        y = skew_normal_peak_shape(baseline, time, mean, std, alpha, area=area)
         y = pm.Deterministic("y", y)
 
         # likelihood
@@ -537,9 +537,9 @@ def define_model_skew(time: np.ndarray, intensity: np.ndarray) -> pm.Model:
     return pmodel
 
 
-def double_skew_normal_posterior(baseline, time: np.ndarray, mean, std, alpha, *, area):
+def double_skew_normal_peak_shape(baseline, time: np.ndarray, mean, std, alpha, *, area):
     """
-    Define a univariate ordered skew normal distribution as the posterior.
+    Model a peak shaped like the a univariate ordered skew normal distribution.
 
     Parameters
     ----------
@@ -656,7 +656,7 @@ def define_model_double_skew_normal(time: np.ndarray, intensity: np.ndarray) -> 
         pm.Deterministic("sn", height / noise, dims=("subpeak",))
 
         # posterior
-        y = double_skew_normal_posterior(baseline, time, mean, std, alpha, area=area)
+        y = double_skew_normal_peak_shape(baseline, time, mean, std, alpha, area=area)
         y = pm.Deterministic("y", y)
 
         # likelihood

--- a/peak_performance/plots.py
+++ b/peak_performance/plots.py
@@ -18,7 +18,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import os
 from pathlib import Path
-from typing import Sequence, Union, Optional
+from typing import Optional, Sequence, Union
 
 import arviz as az
 import numpy as np
@@ -188,7 +188,9 @@ def plot_posterior_predictive(
                 )
         else:
             for format in save_formats:
-                fig.savefig(Path(path) / f"{identifier}_predictive_posterior.{format}", format=format)
+                fig.savefig(
+                    Path(path) / f"{identifier}_predictive_posterior.{format}", format=format
+                )
         plt.close(fig)
 
     return

--- a/peak_performance/plots.py
+++ b/peak_performance/plots.py
@@ -18,7 +18,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import os
 from pathlib import Path
-from typing import Sequence, Union
+from typing import Sequence, Union, Optional
 
 import arviz as az
 import numpy as np
@@ -31,7 +31,7 @@ def plot_raw_data(
     identifier: str,
     time: np.ndarray,
     intensity: np.ndarray,
-    path: Union[str, os.PathLike],
+    path: Optional[Union[str, os.PathLike]],
     save_formats: Sequence[str] = ("png", "svg"),
 ):
     """
@@ -62,9 +62,10 @@ def plot_raw_data(
     plt.xticks(size=11.5)
     plt.yticks(size=11.5)
     fig.tight_layout()
-    for format in save_formats:
-        fig.savefig(Path(path) / f"{identifier}_NoPeak.{format}", format=format)
-    plt.close(fig)
+    if path is not None:
+        for format in save_formats:
+            fig.savefig(Path(path) / f"{identifier}_NoPeak.{format}", format=format)
+        plt.close(fig)
 
     return
 
@@ -74,7 +75,6 @@ def plot_density(
 ):
     """
     Method to plot the original data points alongside the posterior predictive plot (percentiles marked with a black, dashed line).
-    Serves as a more accurate comparison between data and model than comparing data and posterior distribution.
 
     Parameters
     ----------
@@ -135,7 +135,7 @@ def plot_posterior_predictive(
     identifier: str,
     time: np.ndarray,
     intensity: np.ndarray,
-    path: Union[str, os.PathLike],
+    path: Optional[Union[str, os.PathLike]],
     idata: az.InferenceData,
     discarded: bool,
     save_formats: Sequence[str] = ("png", "svg"),
@@ -179,16 +179,17 @@ def plot_posterior_predictive(
     plt.yticks(size=11.5)
     plt.legend()
     fig.tight_layout()
-    # if signal was discarded, add a "_NoPeak" to the file name
-    if discarded:
-        for format in save_formats:
-            fig.savefig(
-                Path(path) / f"{identifier}_predictive_posterior_NoPeak.{format}", format=format
-            )
-    else:
-        for format in save_formats:
-            fig.savefig(Path(path) / f"{identifier}_predictive_posterior.{format}", format=format)
-    plt.close(fig)
+    if path is not None:
+        # if signal was discarded, add a "_NoPeak" to the file name
+        if discarded:
+            for format in save_formats:
+                fig.savefig(
+                    Path(path) / f"{identifier}_predictive_posterior_NoPeak.{format}", format=format
+                )
+        else:
+            for format in save_formats:
+                fig.savefig(Path(path) / f"{identifier}_predictive_posterior.{format}", format=format)
+        plt.close(fig)
 
     return
 
@@ -197,7 +198,7 @@ def plot_posterior(
     identifier: str,
     time: np.ndarray,
     intensity: np.ndarray,
-    path: Union[str, os.PathLike],
+    path: Optional[Union[str, os.PathLike]],
     idata: az.InferenceData,
     discarded: bool,
     save_formats: Sequence[str] = ("png", "svg"),
@@ -246,14 +247,15 @@ def plot_posterior(
     plt.xticks(size=11.5)
     plt.yticks(size=11.5)
     fig.tight_layout()
-    # if signal was discarded, add a "_NoPeak" to the file name
-    if discarded:
-        for format in save_formats:
-            fig.savefig(Path(path) / f"{identifier}_posterior_NoPeak.{format}", format=format)
-    else:
-        for format in save_formats:
-            fig.savefig(Path(path) / f"{identifier}_posterior.{format}", format=format)
-    plt.close(fig)
+    if path is not None:
+        # if signal was discarded, add a "_NoPeak" to the file name
+        if discarded:
+            for format in save_formats:
+                fig.savefig(Path(path) / f"{identifier}_posterior_NoPeak.{format}", format=format)
+        else:
+            for format in save_formats:
+                fig.savefig(Path(path) / f"{identifier}_posterior.{format}", format=format)
+        plt.close(fig)
 
     return
 
@@ -261,7 +263,7 @@ def plot_posterior(
 def plot_model_comparison(
     df_comp: pandas.DataFrame,
     identifier: str,
-    path: Union[str, os.PathLike],
+    path: Optional[Union[str, os.PathLike]],
     save_formats: Sequence[str] = ("png", "svg"),
 ):
     """
@@ -282,8 +284,9 @@ def plot_model_comparison(
     axes = az.plot_compare(df_comp, insample_dev=False)
     fig = axes.figure
     plt.tight_layout()
-    for format in save_formats:
-        fig.savefig(Path(path) / f"model_comparison_{identifier}.{format}", format=format)
-    plt.close(fig)
+    if path is not None:
+        for format in save_formats:
+            fig.savefig(Path(path) / f"model_comparison_{identifier}.{format}", format=format)
+        plt.close(fig)
 
     return

--- a/peak_performance/test_models.py
+++ b/peak_performance/test_models.py
@@ -27,10 +27,10 @@ def test_initial_guesses():
 
 
 class TestDistributions:
-    def test_normal_posterior(self):
+    def test_normal_peak_shape(self):
         x = np.linspace(-5, 10, 10000)
         expected = st.norm.pdf(x, 3, 2)
-        actual_pt = models.normal_posterior(0, x, 3, 2, height=np.max(expected))
+        actual_pt = models.normal_peak_shape(0, x, 3, 2, height=np.max(expected))
         # cast arrays to float data type in order to avoid error of np.testing.assert_allclose() due to using np.isfinite under the hood
         actual = actual_pt.eval().astype(float)
         expected = expected.astype(float)
@@ -38,11 +38,11 @@ class TestDistributions:
         np.testing.assert_allclose(expected, actual, atol=0.0000001)
         pass
 
-    def test_double_normal_posterior(self):
+    def test_double_normal_peak_shape(self):
         x = np.linspace(5, 12, 10000)
         y1 = st.norm.pdf(x, loc=7.5, scale=0.6)
         y2 = st.norm.pdf(x, loc=9, scale=0.4) * 2
-        y_double_pt = models.double_normal_posterior(
+        y_double_pt = models.double_normal_peak_shape(
             0, x, (7.5, 9), (0.6, 0.4), height=(np.max(y1), np.max(y2))
         )
         y_double = y_double_pt.eval().astype(float)
@@ -105,11 +105,11 @@ class TestDistributions:
         np.testing.assert_allclose(expected_mode_skew, actual_mode, atol=5e-3)
         pass
 
-    def test_skew_normal_posterior(self):
+    def test_skew_normal_peak_shape(self):
         x = np.linspace(-1, 5.5, 10000)
         # test first with positive alpha
         expected = st.skewnorm.pdf(x, 3, loc=1.2, scale=1.1)
-        actual_pt = models.skew_normal_posterior(0, x, 1.2, 1.1, 3, area=1)
+        actual_pt = models.skew_normal_peak_shape(0, x, 1.2, 1.1, 3, area=1)
         # cast arrays to float data type in order to avoid error of np.testing.assert_allclose() due to using np.isfinite under the hood
         actual = actual_pt.eval().astype(float)
         expected = expected.astype(float)
@@ -118,7 +118,7 @@ class TestDistributions:
 
         # test again with negative alpha
         expected = st.skewnorm.pdf(x, -3, loc=1.2, scale=1.1)
-        actual_pt = models.skew_normal_posterior(0, x, 1.2, 1.1, -3, area=1)
+        actual_pt = models.skew_normal_peak_shape(0, x, 1.2, 1.1, -3, area=1)
         # cast arrays to float data type in order to avoid error of np.testing.assert_allclose() due to using np.isfinite under the hood
         actual = actual_pt.eval().astype(float)
         expected = expected.astype(float)
@@ -133,8 +133,8 @@ class TestDistributions:
         height = np.max(y)
         area = scipy.integrate.quad(lambda x: st.norm.pdf(x, loc=1, scale=1), -10, 10)[0]
         x = np.linspace(-10, 10, 10000)
-        y_actual_pt = models.normal_posterior(0, x, 1, 1, height=height)
-        y_skew_actual_pt = models.skew_normal_posterior(0, x, 1, 1, 0, area=area)
+        y_actual_pt = models.normal_peak_shape(0, x, 1, 1, height=height)
+        y_skew_actual_pt = models.skew_normal_peak_shape(0, x, 1, 1, 0, area=area)
         y_actual = y_actual_pt.eval().astype(float)
         y_skew_actual = y_skew_actual_pt.eval().astype(float)
         # many values are extremely close to zero so rtol was increased.
@@ -142,7 +142,7 @@ class TestDistributions:
         np.testing.assert_allclose(y_skew_actual, y_actual, atol=1e-20, rtol=0.9)
         pass
 
-    def test_double_skew_normal_posterior(self):
+    def test_double_skew_normal_peak_shape(self):
         x1 = np.arange(4, 6, 0.1)
         x2 = np.arange(6, 8, 0.1)
         alpha = 5
@@ -150,7 +150,7 @@ class TestDistributions:
         y2 = st.skewnorm.pdf(x2, alpha, loc=6.3, scale=0.2)
         time = np.array(list(x1) + list(x2))
         intensity = np.array(list(y1) + list(y2))
-        y_double_pt = models.double_skew_normal_posterior(
+        y_double_pt = models.double_skew_normal_peak_shape(
             0, time, (5, 6.3), (0.2, 0.2), (5, 5), area=(1, 1)
         )
         y_double = y_double_pt.eval().astype(float)


### PR DESCRIPTION
1) Change plotting functions in the `plots` module to allow the usage of said functions without saving the created plots by stating `path=None`.
2) Changed mentions of "posterior" to "peak shape" in the `models` module.