### PR TITLE
Unpin NumPy version limit

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,4 @@ pymc>=5.9.1
 pytensor
 scipy
 openpyxl
-numpy<1.26.0
+numpy


### PR DESCRIPTION
NumPy versions are dictated by PyMC/PyTensor dependencies, so there's no point in pinning them here.