### PR TITLE
Fix pre-commit environment creation

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -11,4 +11,6 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - uses: actions/setup-python@v5
+      with:
+        python-version: '3.x'
     - uses: pre-commit/action@v3.0.1


### PR DESCRIPTION
GitHub-wide issue due to incompatibility between `setup-python@v5` and the new default `ubuntu-latest` runner.

This is the third project where I have to fix this 🤐