### PR TITLE
Format link to documentation as link

### DIFF
--- a/paper/paper.md
+++ b/paper/paper.md
@@ -134,7 +134,7 @@ It provides built-in uncertainty quantification by Bayesian parameter estimation
 Regarding peak acceptance, it improves on vendor software solutions with more sophisticated, multi-layered metrics for decision making based on convergence of the parameter estimation, as well as the uncertainties of peak parameters.
 Finally, it allows the addition of new models to describe peak intensity functions with just a few minor code changes, thus lending itself to expansion to data from other chromatographic techniques.
 The design of $\texttt{PeakPerformance}$ accommodates users with little programming experience by supplying convenience functions and relying on Microsoft Excel for data input and reporting.
-Its code repository on GitHub features automated unit tests, and an automatically built documentation (https://peak-performance.rtfd.io).
+Its code repository on GitHub features automated unit tests, and an automatically built documentation [https://peak-performance.rtfd.io](https://peak-performance.rtfd.io).
 
 
 ### Author contributions


### PR DESCRIPTION
I noticed that in the generated PDF it didn't render as a clickable link.